### PR TITLE
Remove Obsoletes from lustre-client.

### DIFF
--- a/lustre.spec.in
+++ b/lustre.spec.in
@@ -217,7 +217,6 @@ Requires: lustre-osd-mount
 Obsoletes: lustre-server < %{version}
 Provides: lustre-server = %{version}-%{release}
 %endif
-Obsoletes: lustre-client < %{version}
 Provides: lustre-client = %{version}-%{release}
 %if "%{_vendor}" == "redhat" || "%{_vendor}" == "fedora"
 #suse don't support selinux


### PR DESCRIPTION
This was causing grief when using metapkgs on RHEL, because DKMS pkgs also provide lustre-client.