### PR TITLE
Fix github actions fetch permissions

### DIFF
--- a/.github/workflows/fetch-upstream.yml
+++ b/.github/workflows/fetch-upstream.yml
@@ -19,6 +19,8 @@ jobs:
   Refresh-Upstream:
     name: update_upstream_branches
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Had to add that permissions block as a result of this github change that went into effect on Feb 1st.

@csmuell 
Since that action runs out of main_ms, I'm only PRing it into that branch but lmk if you feel strongly about PRing that into the new 2.15.4 branch or any other branches. 


Passing run:
https://github.com/microsoft/amlFilesystem-lustre/actions/runs/7786864233