### PR TITLE
debian: revert upstream LU-18632 to fix DKMS/utils header collision

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -475,9 +475,13 @@ binary-$(DKMS_PKG): patch-stamp
 	# Clean it up
 	$(MAKE) -C debian/$(DKMS_PKG)/usr/src/lustre-client-modules-$(UPVERSION) -f debian/rules clean
 
-	$(MAKE) install -C lustre/include DESTDIR=$(CURDIR)/debian/$(DKMS_PKG)
-	$(MAKE) install -C lnet/include DESTDIR=$(CURDIR)/debian/$(DKMS_PKG)
-	rm -rf $(CURDIR)/debian/$(DKMS_PKG)/usr/include/lustre
+	# AMLFS-local: upstream LU-18632 chunk reverted (PBI #38334876).
+	# Upstream added these 3 lines to copy UAPI headers into the DKMS deb, but
+	# AMLFS already ships those same headers in lustre-client-utils. Shipping in
+	# both causes a dpkg file collision (/usr/include/linux/{lnet,lustre}/*.h)
+	# on every Ubuntu install. We keep the headers in utils only (where they have
+	# always been) and let the DKMS metapackage's Depends on utils make them
+	# available to DKMS users. Do NOT re-add without first solving the collision.
 
 	# Put the DKMS configuration file in place
 	sed -e 's/[@]UPVERSION[@]/$(UPVERSION)/' debian/dkms.conf.in > debian/$(DKMS_PKG)/usr/src/lustre-client-modules-$(UPVERSION)/dkms.conf


### PR DESCRIPTION
## Validation

Will be validated by the PR-branch run of the AMLFS Unified Client Build pipeline (queued after PR creation). Validation criteria:

1. `dpkg-deb -c <dkms.deb>` MUST NOT list `/usr/include/linux/(lnet|lustre)/*.h`
2. `dpkg-deb -c <utils.deb>` MUST list those paths (unchanged)
3. Install dance on noble:
   - `apt install ./utils.deb ./dkms.deb` succeeds (was: collision)
   - `apt install ./dkms.deb ./utils.deb` succeeds
4. Headers reachable after co-install: `dpkg -S /usr/include/linux/lnet/libcfs_debug.h` reports utils
5. Partial-remove regression: after `apt remove lustre-client-modules-dkms-*`, headers survive (utils retains ownership)
6. Reproduces Zheyu's exact `apt install amlfs-lustre-client-dkms-2.17.0-*` cleanly

A Stream D CI bouncer (payload-level + install-dance assertions) lands in a follow-up `Avere-laaso-clients` PR to prevent regression of this exact failure class.

## Why

Zheyu reported on a 2.17.0 client image build:

```
==> hpc_build.azure-arm.hpc: Unpacking lustre-client-modules-dkms-2.17.0-18-g4ad5f00 ...
==> hpc_build.azure-arm.hpc: dpkg: error processing archive .../lustre-client-modules-dkms-...deb (--unpack):
==> hpc_build.azure-arm.hpc:  trying to overwrite '/usr/include/linux/lnet/libcfs_debug.h', which is also in package lustre-client-2.17.0-18-g4ad5f00
==> hpc_build.azure-arm.hpc: E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Root cause: upstream [LU-18632](https://review.whamcloud.com/c/fs/lustre-release/+/57835) (commit `455bde17d1`, Jan 14 2025) added 3 lines to `debian/rules` that copy UAPI headers (`/usr/include/linux/{lnet,lustre}/*`) into the DKMS deb. AMLFS's `lustre-client-utils` (our 'kitchen-sink' utils deb) has always shipped those same headers, so the two packages collide at install time on every Ubuntu build that picks up post-LU-18632 lustre source.

## Fix

Revert the 3-line LU-18632 chunk in our fork's `debian/rules`. Replace with an inline comment marking the local divergence and linking back to the PBI.

DKMS deb stops shipping the colliding paths. Utils is completely untouched. DKMS metapackage `Depends: lustre-client-@UPVERSION@ | lustre-client-utils` already pulls utils in every AMLFS-documented install path, so DKMS users still get the headers — just exclusively from utils (same as pre-Jan-2025, before LU-18632).

## Why not alternatives

| Option | Why rejected |
|---|---|
| Strip headers from utils | Breaks per-KVERS power users (HSM copytools, changelog consumers, custom layout/LNet tooling) |
| Bidirectional `Replaces:` declarations | dpkg `Replaces:` transfers file ownership at unpack. Customer who later removes only the DKMS deb (e.g., switching to per-KVERS) silently loses the headers. Caught by deep-review skeptic. |
| Split `lustre-client-headers` deb | Major rearchitecture; out of scope |
| Contribute upstream | Out of scope per direction |
| Post-process DKMS deb with `dpkg-deb -R/-b` | Repack/reproducibility concerns; cleaner to fix at source |

## Scope

Single file, single repo:
- `debian/rules` (3 lines deleted, 7-line comment added)

Per-KVERS kmod packaging unaffected (build script already strips all of `/usr`). RHEL/AL3 packaging unaffected (no analogous chunk in spec files). `Avere-laaso-clients` packaging completely unchanged.

## Linked work item

Fixes AB#38334876
